### PR TITLE
Update goroyale description in docs to be consistent and reflect my username change

### DIFF
--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -71,9 +71,9 @@ Python Async + Sync wrapper
 
 A wrapper for RoyaleAPI written in Go (Golang).
 
-- Repo: https://github.com/Altarrel/goroyale
-- Author: Altarrel
-    - Github: https://github.com/Altarrel
+- Repo: https://github.com/jegfish/goroyale
+- Author: jegfish
+    - Github: https://github.com/jegfish
 
 ## Retired / Invalid /  No longer maintained
 

--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -71,10 +71,6 @@ Python Async + Sync wrapper
 
 A wrapper for RoyaleAPI written in Go (Golang).
 
-- Easy access to endpoints through methods in `goroyale.Client`
-- Simple ratelimit handling where a special error is returned (`RatelimitError`) with an attribute `RetryAfter` representing how long to wait before running another request.
-- Field Filter and other query parameters through a `url.Values` or `map[string][]string` object passed to endpoint methods.
-
 - Repo: https://github.com/Altarrel/goroyale
 - Author: Altarrel
     - Github: https://github.com/Altarrel


### PR DESCRIPTION
The goroyale description in the wrappers page of the docs had several lines of information, while other wrappers had single lines. This information was outdated anyway.

I also updated the links to reflect my username change, although GitHub keeps redirect links.