### PR TITLE
Fixed Brawl Stars API Proxy section

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -28,7 +28,7 @@ Follow the instructions above, and substitute domains accordingly:
 
 ## Brawl Stars API Proxy
 
-- [Brawl Starss API](https://developer.clashofclans.com)
+- [Brawl Stars API](https://developer.brawlstars.com)
 - https://api.brawlstars.com
 - https://bsproxy.royaleapi.dev
 


### PR DESCRIPTION
Changed the text and the hyperlink to the Brawl Stars official API homepage.